### PR TITLE
bug fix for the chem array index

### DIFF
--- a/WRF/module_bl_mynnedmf_driver.F90
+++ b/WRF/module_bl_mynnedmf_driver.F90
@@ -698,9 +698,9 @@
 
 #if (WRF_CHEM == 1)
       if (mix_chem) then
-         do ic = 1,nchem
+         do n = 1,nchem
             do k = kts,kte
-               chem3d(i,k,j,ic) = max(1.e-12, chem(k,ic))
+               chem3d(i,k,j,n) = max(1.e-12, chem(k,n))
             enddo
          enddo
       endif


### PR DESCRIPTION
the loop variable ic was undefined for the chem arrays.
It was meant to be changed to n, which does exist.