### PR TITLE
Updating MYNN to reduce diffusion in stable conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@
 
 # All copies in the top dir
 Makefile
-module_mynnedmf_common.F90
-module_mynnedmf_driver.F90
+module_bl_mynnedmf_common.F90
+module_bl_mynnedmf_driver.F90


### PR DESCRIPTION
Updating MYNN to reduce diffusion in stable conditions + bug fix in ".gitignore" file. The diffusion changes are:
(a) reduced the lower bounds of Sh (from 0.02 to 0.004) - very little impact, limits were already reasonable
(b) reduced lower bound of Sh and Sm in clouds (from 0.04 to 0.02) - very little impact, limits were already reasonable
(c) reduce buoyancy length scale (alp2=0.3 to 0.25) - Slightly more shear, slightly stronger LLJs.
(d) switch back to linear blending of mixing length (same as HRRRv4) - This has a relatively strong impact on LLJs
(e) Pr limit = 6, reduces Km when Ri > 1 - Slightly more shear, slightly stronger LLJs.

