### PR TITLE
Adding explicit solver option (bl_mynn_edmf=2) and making WFA & IFA bounds dycore dependent.

### DIFF
--- a/MPAS/module_bl_mynnedmf_common.F90
+++ b/MPAS/module_bl_mynnedmf_common.F90
@@ -81,6 +81,13 @@
  real(kind_phys),parameter:: xlvcp  = xlv/cp
  real(kind_phys),parameter:: g_inv  = 1./grav
 
+ real(kind_phys), parameter :: wfa_max = 800e12  !kg-1
+ real(kind_phys), parameter :: wfa_min = 1e6     !kg-1
+ real(kind_phys), parameter :: ifa_max = 500e6   !kg-1
+ real(kind_phys), parameter :: ifa_min = 0.0     !kg-1
+ real(kind_phys), parameter :: wfa_ht  = 2000.   !meters
+ real(kind_phys), parameter :: ifa_ht  = 10000.  !meters 
+
 ! grav   = g
 ! t0c    = svpt0        != 273.15
 ! ep_3   = 1.-ep_2      != 0.378                                                                                   

--- a/WRF/module_bl_mynnedmf_common.F90
+++ b/WRF/module_bl_mynnedmf_common.F90
@@ -68,7 +68,13 @@
  real(kind_phys),parameter:: tice  = 240.0  !-33 (C), temp at saturation w.r.t. ice
  real(kind_phys),parameter:: grav  = g
  real(kind_phys),parameter:: t0c   = svpt0        != 273.15
-
+ real(kind_phys),parameter:: wfa_max = 800e6  !kg-1
+ real(kind_phys),parameter:: wfa_min = 1e6     !kg-1
+ real(kind_phys),parameter:: ifa_max = 300e6   !kg-1
+ real(kind_phys),parameter:: ifa_min = 0.0     !kg-1
+ real(kind_phys),parameter:: wfa_ht  = 2000.   !meters
+ real(kind_phys),parameter:: ifa_ht  = 10000.  !meters
+ 
 ! To be derived in the init routine
  real(kind_phys),parameter:: ep_3   = 1.-ep_2 != 0.378
  real(kind_phys),parameter:: gtr    = grav/tref


### PR DESCRIPTION
Adding explicit solver option (bl_mynn_edmf=2) and making WFA & IFA bounds dycore dependent.

New option bl_mynn_edmf=2 uses an explicit solver for the mass flux component with and addition option "upwind" (internal parameter for now), which is set to 1.0 for upwind differencing or 0.5 for centered differencing. Note that for the original implicit method (bl_mynn_edmf=1) uses a centered differencing. This option was developed by Kay Suselj (NASA/JPL) and is considered still under development although initial tests look reasonable.

Moved the parameters that regulate the bounds for the ice & water friendly aerosols to the common file. This is because a better solution has already been found for MPAS, but not yet implemented for WRF, so WRF needs some rather draconian limits at this time.

More precision-related cleaning was added to this PR (i.e., 1.0 changed to "one", 0.5 changed to "half", etc...)