### PR TITLE
Adding bl_mynn_edmf_dd as namelist option

### DIFF
--- a/MPAS/module_bl_mynnedmf_driver.F90
+++ b/MPAS/module_bl_mynnedmf_driver.F90
@@ -524,6 +524,7 @@
             bl_mynn_mixlength  = bl_mynn_mixlength    , &
             closure            = bl_mynn_closure      , &
             bl_mynn_edmf       = bl_mynn_edmf         , &
+            bl_mynn_edmf_dd    = bl_mynn_edmf_dd      , &
             bl_mynn_edmf_mom   = bl_mynn_edmf_mom     , &
             bl_mynn_edmf_tke   = bl_mynn_edmf_tke     , &
             bl_mynn_mixscalars = bl_mynn_mixscalars   , &

--- a/WRF/module_bl_mynnedmf_driver.F90
+++ b/WRF/module_bl_mynnedmf_driver.F90
@@ -105,7 +105,7 @@
                   bl_mynn_tkeadvect , tke_budget        , bl_mynn_cloudpdf   , bl_mynn_mixlength  , &
                   bl_mynn_closure   , bl_mynn_edmf      , bl_mynn_edmf_mom   , bl_mynn_edmf_tke   , &
                   bl_mynn_output    , bl_mynn_mixscalars, bl_mynn_mixaerosols, bl_mynn_mixnumcon  , &
-                  bl_mynn_cloudmix  , bl_mynn_mixqt                                                 &                  
+                  bl_mynn_cloudmix  , bl_mynn_mixqt     , bl_mynn_edmf_dd                           &
 #if(WRF_CHEM == 1)
                   ,mix_chem         , chem3d            , vd3d               , nchem              , &
                   kdvel             , ndvel             , num_vert_mix                              &
@@ -149,6 +149,7 @@
          bl_mynn_mixlength,                             &
          icloud_bl,                                     &
          bl_mynn_edmf,                                  &
+         bl_mynn_edmf_dd,                               &
          bl_mynn_edmf_mom,                              &
          bl_mynn_edmf_tke,                              &
          bl_mynn_cloudmix,                              &
@@ -581,6 +582,7 @@
             bl_mynn_mixlength  = bl_mynn_mixlength    , &
             closure            = bl_mynn_closure      , &
             bl_mynn_edmf       = bl_mynn_edmf         , &
+            bl_mynn_edmf_dd    = bl_mynn_edmf_dd      , &
             bl_mynn_edmf_mom   = bl_mynn_edmf_mom     , &
             bl_mynn_edmf_tke   = bl_mynn_edmf_tke     , &
             bl_mynn_mixscalars = bl_mynn_mixscalars   , &


### PR DESCRIPTION
Removing the hardcoded internal option "bl_mynn_edmf_dd" and making it a namelist option. This new namelist option will also control the analytical profile method for radiative cloud-top cooling, since it only downdrafts or the analytical profile method can be used at a time. This PR also removes the hardcoded option bl_mynn_topdown.

bl_mynn_edmf_dd = 0 : both inactive (default, for now)
bl_mynn_edmf_dd = 1 : downdrafts active
bl_mynn_edmf_dd = 2 : analytical profile method active