### PR TITLE
Some tuning for level 2.7 and pulling some parameters from common module

### DIFF
--- a/MPAS/module_bl_mynnedmf_common.F90
+++ b/MPAS/module_bl_mynnedmf_common.F90
@@ -44,12 +44,6 @@
 ! real:: rvovrd       != r_v/r_d != 1.608
 
 ! Specified locally
- real(kind_phys),parameter:: zero   = 0.0
- real(kind_phys),parameter:: half   = 0.5
- real(kind_phys),parameter:: one    = 1.0
- real(kind_phys),parameter:: two    = 2.0
- real(kind_phys),parameter:: onethird  = 1./3.
- real(kind_phys),parameter:: twothirds = 2./3.
  real(kind_phys),parameter:: tref  = 300.0   ! reference temperature (K)
  real(kind_phys),parameter:: TKmin = 253.0   ! for total water conversion, Tripoli and Cotton (1981)
 ! real(kind_phys),parameter:: p1000mb=100000.0

--- a/WRF/module_bl_mynnedmf_common.F90
+++ b/WRF/module_bl_mynnedmf_common.F90
@@ -53,12 +53,6 @@
 ! integer, parameter :: sp = selected_real_kind(6, 37)
 ! integer, parameter :: dp = selected_real_kind(15, 307)
 ! integer, parameter :: kind_phys = sp
- real(kind_phys),parameter:: zero   = 0.0
- real(kind_phys),parameter:: half   = 0.5
- real(kind_phys),parameter:: one    = 1.0
- real(kind_phys),parameter:: two    = 2.0
- real(kind_phys),parameter:: onethird  = 1./3.
- real(kind_phys),parameter:: twothirds = 2./3.
  real(kind_phys),parameter:: tref  = 300.0   ! reference temperature (K)
  real(kind_phys),parameter:: TKmin = 253.0   ! for total water conversion, Tripoli and Cotton (1981)
 ! real(kind_phys),parameter:: p1000mb=100000.0


### PR DESCRIPTION
Pulled parameters out of the "common" module that are not model-framework-dependent and added some more parameters for model precision control reasons.

Some minor tuning was done for the higher-order moments, implementing some max/mins that shouldn't limit the natural ranges of these variables for simulations on Earth. I wouldn't recommend other terrestrial bodies. This may slightly help the lower-order configurations which diagnose these variables and sometimes suffer from wild fluctuations.