### PR TITLE
Tuning for WFIP3-EXP9: MF CF, stable PBLH, and lots of precision/parameter mods

### DIFF
--- a/MPAS/module_bl_mynnedmf_driver.F90
+++ b/MPAS/module_bl_mynnedmf_driver.F90
@@ -484,7 +484,7 @@
             sqc1            = sqc1          , sqi1        = sqi1          , sqs1        = sqs1         , &
             qnc1            = nc1           , qni1        = ni1           , qnwfa1      = nwfa1        , &
             qnifa1          = nifa1         , qnbca1      = nbca1         , ozone1      = qoz1         , &
-            p1              = p1            , ex1         = exner1        , rho1        = rho1         , &
+            pres1           = p1            , ex1         = exner1        , rho1        = rho1         , &
             tk1             = tt1           , xland       = xland1        , ts          = ts1          , &
             qsfc            = qsfc1         , ps          = ps1           , ust         = ust1         , &
             ch              = ch1           , hfx         = hfx1          , qfx         = qfx1         , &

--- a/WRF/module_bl_mynnedmf_driver.F90
+++ b/WRF/module_bl_mynnedmf_driver.F90
@@ -543,7 +543,7 @@
             sqc1            = sqc1          , sqi1        = sqi1          , sqs1        = sqs1         , &
             qnc1            = qnc1          , qni1        = qni1          , qnwfa1      = qnwfa1       , &
             qnifa1          = qnifa1        , qnbca1      = qnbca1        , ozone1      = ozone1       , &
-            p1              = p1            , ex1         = ex1           , rho1        = rho1         , &
+            pres1           = p1            , ex1         = ex1           , rho1        = rho1         , &
             tk1             = tk1           , xland       = xland1        , ts          = ts1          , &
             qsfc            = qsfc1         , ps          = ps1           , ust         = ust1         , &
             ch              = ch1           , hfx         = hfx1          , qfx         = qfx1         , &


### PR DESCRIPTION
Two physics changes:
1) design (and switch) to extended Chab-Becht mass-flux cloud fraction and now use the deRoode method as a lower bound. This helps with the (lack of) variation of CF. This can increase CF in post cold-frontal situations but decrease CF minimums in the extratropical oceans.
2) Tweak the stable PBLH (=700u*) so the parameter 700 varies with low-level stability. It can now drop to 500 in very stable conditions. This increases the amount of times the PBLH drops below 100 m, which seems too rare with the original form.

Many other paramers changes for precision. I added several new parameters, like
p1 = 0.1
p2= 0.2
etc.
This resulted in having to change the name of the incoming pressure array from p1 to pres1.