### PR TITLE
Adding moist static stability  (bl_mynn_mss) option

### DIFF
--- a/MPAS/module_bl_mynnedmf_driver.F90
+++ b/MPAS/module_bl_mynnedmf_driver.F90
@@ -49,7 +49,7 @@
                   bl_mynn_closure   , bl_mynn_stfunc    , bl_mynn_topdown    , bl_mynn_scaleaware , &
                   bl_mynn_dheat_opt , bl_mynn_edmf      , bl_mynn_edmf_dd    , bl_mynn_edmf_mom   , &
                   bl_mynn_edmf_tke  , bl_mynn_output    , bl_mynn_mixscalars , bl_mynn_mixaerosols, &
-                  bl_mynn_mixnumcon , bl_mynn_cloudmix  , bl_mynn_mixqt      ,                      &
+                  bl_mynn_mixnumcon , bl_mynn_cloudmix  , bl_mynn_mixqt      , bl_mynn_mss        , &
                   errmsg            , errflg                                                        &
 #if(WRF_CHEM == 1)
                  ,mix_chem   , nchem        , kdvel       , ndvel        , chem3d        , vd3d   , &
@@ -100,6 +100,7 @@
     bl_mynn_mixnumcon,  &!
     bl_mynn_cloudmix,   &!
     bl_mynn_mixqt,      &!
+    bl_mynn_mss,        &!
     bl_mynn_tkebudget    !
  
  integer,intent(in):: &
@@ -533,6 +534,7 @@
             bl_mynn_output     = bl_mynn_output       , &
             bl_mynn_cloudmix   = bl_mynn_cloudmix     , &
             bl_mynn_mixqt      = bl_mynn_mixqt        , &
+            bl_mynn_mss        = bl_mynn_mss          , &
             icloud_bl          = icloud_bl            , &
             spp_pbl            = spp_pbl              , &
             kts = kts , kte = kte , errmsg = errmsg , errflg = errflg )

--- a/WRF/module_bl_mynnedmf_driver.F90
+++ b/WRF/module_bl_mynnedmf_driver.F90
@@ -105,7 +105,7 @@
                   bl_mynn_tkeadvect , tke_budget        , bl_mynn_cloudpdf   , bl_mynn_mixlength  , &
                   bl_mynn_closure   , bl_mynn_edmf      , bl_mynn_edmf_mom   , bl_mynn_edmf_tke   , &
                   bl_mynn_output    , bl_mynn_mixscalars, bl_mynn_mixaerosols, bl_mynn_mixnumcon  , &
-                  bl_mynn_cloudmix  , bl_mynn_mixqt     , bl_mynn_edmf_dd                           &
+                  bl_mynn_cloudmix  , bl_mynn_mixqt     , bl_mynn_edmf_dd    , bl_mynn_mss          &
 #if(WRF_CHEM == 1)
                   ,mix_chem         , chem3d            , vd3d               , nchem              , &
                   kdvel             , ndvel             , num_vert_mix                              &
@@ -158,6 +158,7 @@
          bl_mynn_mixscalars,                            &
          bl_mynn_mixaerosols,                           &
          bl_mynn_mixnumcon,                             &
+         bl_mynn_mss,                                   &
          spp_pbl,                                       &
          tke_budget
  real(kind_phys), intent(in) ::                         &
@@ -591,6 +592,7 @@
             bl_mynn_output     = bl_mynn_output       , &
             bl_mynn_cloudmix   = bl_mynn_cloudmix     , &
             bl_mynn_mixqt      = bl_mynn_mixqt        , &
+            bl_mynn_mss        = bl_mynn_mss          , &
             icloud_bl          = icloud_bl            , &
             spp_pbl            = spp_pbl              , &
             kts = kts , kte = kte , errmsg = errmsg , errflg = errflg )


### PR DESCRIPTION
This PR add the following:
1) Adding bl_mynn_mss namelist option: 0: for use of the buoyancy flux functions, 1 (default): new O'Gorman options modified to better fit with the MYNN-EDMF. This option helps improve the tropical boundary layer height and helps reduce excessive CAPE.
2) some WFIP3 exp10 tuning: The biggest change is the use of the heat-only z/L (as opposed to the full buoyancy flux z/L) for use in the surface layer length scale (els). This was done to step back to the HRRRv4 version, which seems to work better over the cool ocean surfaces.