### PR TITLE
Final tunings for final WFIP3 EXP(10).

### DIFF
--- a/MPAS/module_bl_mynnedmf_driver.F90
+++ b/MPAS/module_bl_mynnedmf_driver.F90
@@ -49,7 +49,7 @@
                   bl_mynn_closure   , bl_mynn_stfunc    , bl_mynn_topdown    , bl_mynn_scaleaware , &
                   bl_mynn_dheat_opt , bl_mynn_edmf      , bl_mynn_edmf_dd    , bl_mynn_edmf_mom   , &
                   bl_mynn_edmf_tke  , bl_mynn_output    , bl_mynn_mixscalars , bl_mynn_mixaerosols, &
-                  bl_mynn_mixnumcon , bl_mynn_cloudmix  , bl_mynn_mixqt      , bl_mynn_mss        , &
+                  bl_mynn_mixnumcon , bl_mynn_cloudmix  , bl_mynn_mixqt      , bl_mynn_ess        , &
                   errmsg            , errflg                                                        &
 #if(WRF_CHEM == 1)
                  ,mix_chem   , nchem        , kdvel       , ndvel        , chem3d        , vd3d   , &
@@ -100,7 +100,7 @@
     bl_mynn_mixnumcon,  &!
     bl_mynn_cloudmix,   &!
     bl_mynn_mixqt,      &!
-    bl_mynn_mss,        &!
+    bl_mynn_ess,        &!
     bl_mynn_tkebudget    !
  
  integer,intent(in):: &
@@ -534,7 +534,7 @@
             bl_mynn_output     = bl_mynn_output       , &
             bl_mynn_cloudmix   = bl_mynn_cloudmix     , &
             bl_mynn_mixqt      = bl_mynn_mixqt        , &
-            bl_mynn_mss        = bl_mynn_mss          , &
+            bl_mynn_ess        = bl_mynn_ess          , &
             icloud_bl          = icloud_bl            , &
             spp_pbl            = spp_pbl              , &
             kts = kts , kte = kte , errmsg = errmsg , errflg = errflg )

--- a/WRF/module_bl_mynnedmf_driver.F90
+++ b/WRF/module_bl_mynnedmf_driver.F90
@@ -105,7 +105,7 @@
                   bl_mynn_tkeadvect , tke_budget        , bl_mynn_cloudpdf   , bl_mynn_mixlength  , &
                   bl_mynn_closure   , bl_mynn_edmf      , bl_mynn_edmf_mom   , bl_mynn_edmf_tke   , &
                   bl_mynn_output    , bl_mynn_mixscalars, bl_mynn_mixaerosols, bl_mynn_mixnumcon  , &
-                  bl_mynn_cloudmix  , bl_mynn_mixqt     , bl_mynn_edmf_dd    , bl_mynn_mss          &
+                  bl_mynn_cloudmix  , bl_mynn_mixqt     , bl_mynn_edmf_dd    , bl_mynn_ess          &
 #if(WRF_CHEM == 1)
                   ,mix_chem         , chem3d            , vd3d               , nchem              , &
                   kdvel             , ndvel             , num_vert_mix                              &
@@ -158,7 +158,7 @@
          bl_mynn_mixscalars,                            &
          bl_mynn_mixaerosols,                           &
          bl_mynn_mixnumcon,                             &
-         bl_mynn_mss,                                   &
+         bl_mynn_ess,                                   &
          spp_pbl,                                       &
          tke_budget
  real(kind_phys), intent(in) ::                         &
@@ -592,7 +592,7 @@
             bl_mynn_output     = bl_mynn_output       , &
             bl_mynn_cloudmix   = bl_mynn_cloudmix     , &
             bl_mynn_mixqt      = bl_mynn_mixqt        , &
-            bl_mynn_mss        = bl_mynn_mss          , &
+            bl_mynn_ess        = bl_mynn_ess          , &
             icloud_bl          = icloud_bl            , &
             spp_pbl            = spp_pbl              , &
             kts = kts , kte = kte , errmsg = errmsg , errflg = errflg )


### PR DESCRIPTION
Had to make some small revisions to reduce the over-ramping of low-level winds seen in the pre-EXP10 tests. This was mainly due (1) to the use of rmolh instead of rmol as input into the els calculation, and (2) no tapering of "clam" near the surface. Other changes were secondary. This final form seems to behave similarly to EXP9 but improves the tropical boundary layer PBLH.

Also changed bl_mynn_mss to bl_mynn_ess, as I prefer effective static stability over moist static stability.