### PR TITLE
driver cleanup for implementations

### DIFF
--- a/MPAS/module_bl_mynnedmf_driver.F90
+++ b/MPAS/module_bl_mynnedmf_driver.F90
@@ -48,8 +48,7 @@
                   qshear            , qbuoy             , qdiss              , sh3d               , &
                   sm3d              , spp_pbl           , pattern_spp        ,                      &
                   bl_mynn_tkeadvect , bl_mynn_tkebudget , bl_mynn_cloudpdf   , bl_mynn_mixlength  , &
-                  bl_mynn_closure   , bl_mynn_stfunc    , bl_mynn_topdown    , bl_mynn_scaleaware , &
-                  bl_mynn_dheat_opt , bl_mynn_edmf      , bl_mynn_edmf_dd    , bl_mynn_edmf_mom   , &
+                  bl_mynn_closure   , bl_mynn_edmf      , bl_mynn_edmf_dd    , bl_mynn_edmf_mom   , &
                   bl_mynn_edmf_tke  , bl_mynn_output    , bl_mynn_mixscalars , bl_mynn_mixaerosols, &
                   bl_mynn_mixnumcon , bl_mynn_cloudmix  , bl_mynn_mixqt      , bl_mynn_ess        , &
                   errmsg            , errflg                                                        &
@@ -86,10 +85,6 @@
  integer,intent(in):: &
     bl_mynn_cloudpdf,   &!
     bl_mynn_mixlength,  &!
-    bl_mynn_stfunc,     &!
-    bl_mynn_topdown,    &!
-    bl_mynn_scaleaware, &!
-    bl_mynn_dheat_opt,  &!
     bl_mynn_edmf,       &!
     bl_mynn_edmf_dd,    &!
     bl_mynn_edmf_mom,   &!
@@ -240,24 +235,30 @@
     qdiss         !
 
 !--- input arguments for PBL and free-tropospheric mixing of chemical species:
- logical,intent(in):: mix_chem
- integer,intent(in):: nchem,ndvel
-
- real(kind=kind_phys),intent(in),dimension(ims:ime,jms:jme),optional:: frp_mean,emis_ant_no
- real(kind=kind_phys),intent(in),dimension(ims:ime,jms:jme,ndvel),optional:: vd3d
- real(kind=kind_phys),intent(inout),dimension(ims:ime,kms:kme,jms:jme,nchem),optional:: chem3d,settle3d
+ logical,intent(in),optional:: mix_chem
+ logical::mix_chem1
+ integer,intent(in),optional:: nchem,ndvel
+ integer::nchem1,ndvel1
  logical,intent(in),optional:: enh_mix
-
+! real(kind=kind_phys),intent(in),dimension(ims:ime,jms:jme),optional:: frp_mean,emis_ant_no
+! real(kind=kind_phys),intent(in),dimension(ims:ime,jms:jme,ndvel),optional:: vd3d
+! real(kind=kind_phys),intent(inout),dimension(ims:ime,kms:kme,jms:jme,nchem),optional:: chem3d,settle3d
+ real(kind=kind_phys),intent(in),dimension(:,:),  optional:: frp_mean,emis_ant_no
+ real(kind=kind_phys),intent(in),dimension(:,:,:),optional:: vd3d
+ real(kind=kind_phys),intent(inout),dimension(:,:,:,:),optional:: chem3d,settle3d
+ !local smoke/chem arrays
  real(kind=kind_phys):: frp1,emisant_no1
- real(kind=kind_phys),dimension(ndvel):: vd1
- real(kind=kind_phys),dimension(kts:kte,nchem):: chem1,settle1
+ !real(kind=kind_phys),dimension(ndvel):: vd1
+ !real(kind=kind_phys),dimension(kts:kte,nchem):: chem1,settle1
+ real(kind=kind_phys),allocatable,dimension(:):: vd1
+ real(kind=kind_phys),allocatable,dimension(:,:):: chem1,settle1
+ 
 !generic scalar array support
  integer, parameter :: nscalars=1
  real(kind=kind_phys),dimension(kts:kte,nscalars):: scalars
  
  integer:: i,k,j,ic
 
- integer:: dheat_opt
  integer:: kpbl1
 
  real(kind=kind_phys):: denom
@@ -440,6 +441,12 @@
 
     if(present(chem3d).and. present(settle3d) .and. present(vd3d) .and. &
        present(frp_mean) .and. present(emis_ant_no)) then
+       mix_chem1 = .true.
+       ndvel1    = ndvel
+       nchem1    = nchem
+       allocate(vd1(ndvel1))
+       allocate(chem1(kts:kte,nchem1))
+       allocate(settle1(kts:kte,nchem1))
        do ic = 1,nchem
          do k = kts,kte
             chem1(k,ic)   = chem3d(i,k,j,ic)
@@ -452,6 +459,12 @@
        frp1        = frp_mean(i,j)
        emisant_no1 = emis_ant_no(i,j)
     else
+       mix_chem1   = .false.
+       ndvel1 	   = 1
+       nchem1 	   = 1
+       allocate(vd1(ndvel1))
+       allocate(chem1(kts:kte,nchem1))
+       allocate(settle1(kts:kte,nchem1))
        chem1       = zero
        settle1     = zero
        vd1         = zero
@@ -510,8 +523,8 @@
             flag_ozone      = f_qoz         , flag_qnc    = f_nc          , flag_qni    = f_ni         , &
             flag_qnwfa      = f_nwfa        , flag_qnifa  = f_nifa        , flag_qnbca  = f_nbca       , &
             pattern_spp_pbl1= pattern_spp1  ,                                                            &
-            mix_chem        = mix_chem      , enh_mix     = enh_mix       , nchem       = nchem        , &
-            ndvel           = ndvel         , chem1       = chem1         , emis_ant_no = emisant_no1  , &
+            mix_chem        = mix_chem1     , enh_mix     = enh_mix       , nchem       = nchem1       , &
+            ndvel           = ndvel1        , chem1       = chem1         , emis_ant_no = emisant_no1  , &
             frp             = frp1          , vdep        = vd1           , settle1     = settle1      , &
             nscalars        = nscalars      , scalars     = scalars       ,                              &
             bl_mynn_tkeadvect  = bl_mynn_tkeadvect    , &
@@ -653,7 +666,7 @@
        enddo
     endif
 
-    if (mix_chem .and. present(chem3d)) then
+    if (mix_chem1 .and. present(chem3d)) then
        do ic = 1,nchem
           do k = kts,kte
              chem3d(i,k,j,ic) = max(1.e-12, chem1(k,ic))

--- a/WRF/module_bl_mynnedmf_driver.F90
+++ b/WRF/module_bl_mynnedmf_driver.F90
@@ -121,22 +121,6 @@
  implicit none
 !------------------------------------------------------------------- 
 
-!smoke/chem: disclaimer: all smoke-related variables are still
-!considered under development in CCPP. Until that work is
-!completed, these flags/arrays must be kept hard-coded as is.
-#if (WRF_CHEM == 1)
- logical, intent(in) :: mix_chem
- integer, intent(in) :: nchem, ndvel, kdvel, num_vert_mix
- logical, parameter ::                                  &
-         enh_mix    =.false.
-#else
- logical, parameter ::                                  &
-         mix_chem   =.false.,                           &
-         enh_mix    =.false.
- integer, parameter :: nchem=2, ndvel=2, kdvel=1,       &
-          num_vert_mix = 1
-#endif
-
 ! NAMELIST OPTIONS (INPUT):
  logical, intent(in) ::                                 &
          bl_mynn_tkeadvect,                             &
@@ -226,17 +210,34 @@
        dqni1,dqnc1,dqnwfa1,dqnifa1,dqnbca1,dozone1
 
 !smoke/chem arrays - no if-defs in module_bl_mynnedmf.F90, so must define arrays
+!smoke/chem: disclaimer: all smoke-related variables are still
+!considered under development in CCPP. Until that work is
+!completed, these flags/arrays must be kept hard-coded as is.
 #if (WRF_CHEM == 1)
+ logical, intent(in) :: mix_chem
+ integer, intent(in) :: nchem, ndvel, kdvel, num_vert_mix
+ logical, parameter  :: enh_mix=.false.
  real(kind_phys), dimension(ims:ime,kms:kme,jms:jme,nchem), intent(inout) :: chem3d
  real(kind_phys), dimension(ims:ime,kdvel,jms:jme, ndvel),  intent(in)    :: vd3d
- real(kind_phys), dimension(kms:kme,nchem)  :: chem, settle1
- real(kind_phys), dimension(ndvel)          :: vd
- real(kind_phys), dimension(ims:ime,jms:jme):: frp_mean, emis_ant_no
 #else
+ logical, parameter  :: mix_chem=.false.
+ logical, parameter  :: enh_mix=.false.
+ integer, parameter  :: nchem=2, ndvel=2, kdvel=1, num_vert_mix = 1
+#endif
  real(kind_phys), dimension(kms:kme,nchem)  :: chem, settle1
  real(kind_phys), dimension(ndvel)          :: vd
  real(kind_phys), dimension(ims:ime,jms:jme):: frp_mean, emis_ant_no
-#endif
+!from MPAS driver:
+! logical,intent(in),optional:: mix_chem
+! logical::mix_chem1
+! integer,intent(in),optional:: nchem,ndvel
+! integer::nchem1,ndvel1
+! real(kind=kind_phys),intent(in),dimension(:,:),  optional:: frp_mean,emis_ant_no
+! real(kind=kind_phys),intent(in),dimension(:,:,:),optional:: vd3d
+! real(kind=kind_phys),intent(inout),dimension(:,:,:,:),optional:: chem3d,settle3d
+! real(kind=kind_phys),allocatable,dimension(:):: vd1
+! real(kind=kind_phys),allocatable,dimension(:,:):: chem1,settle1 
+
 !Generic scalar array support (not yet connected to WRF, but any new scalars that need to be mixed
 !(locally and nonlocally) will need to come through this variables with bl_mynn_mixscalars=1.
  integer, parameter :: nscalars=1
@@ -732,7 +733,7 @@
       endif
 
 #if (WRF_CHEM == 1)
-      if (mix_chem) then
+      if (mix_chem .and. present(chem3d)) then
          do n = 1,nchem
             do k = kts,kte
                chem3d(i,k,j,n) = max(1.e-12, chem(k,n))


### PR DESCRIPTION
The main changes for implementations into NCAR's authoritative version of MPAS:

1. remove unused namelist options added for the other MYNN in MPAS (added without authorization).
2. change the way the smoke/chem arrays are used, especially in the MPAS driver, because they do not exist in NCAR's version of MPAS yet. 