### PR TITLE
add deallocations for smoke arrays

### DIFF
--- a/MPAS/module_bl_mynnedmf_driver.F90
+++ b/MPAS/module_bl_mynnedmf_driver.F90
@@ -673,6 +673,9 @@
           enddo
        enddo
     endif
+    deallocate(vd1)
+    deallocate(chem1)
+    deallocate(settle1)
 
  enddo !i
  enddo !j


### PR DESCRIPTION
missing array deallocations weren't notice by intel compiler until additional debug flags were added.