### PR TITLE
removing icloud_bl from mynn-edmf)

### DIFF
--- a/MPAS/module_bl_mynnedmf_driver.F90
+++ b/MPAS/module_bl_mynnedmf_driver.F90
@@ -22,7 +22,7 @@
                   kts               , kte               , f_qc               , f_qi               , &
                   f_qs              , f_qoz             , f_nc               , f_ni               , &
                   f_nifa            , f_nwfa            , f_nbca             , initflag           , &
-                  do_restart        , do_DAcycling      , icloud_bl          , delt               , &
+                  do_restart        , do_DAcycling      , delt               ,                      &
                   dx                , xland             , ps                 , ts                 , &
                   qsfc              , ust               , ch                 , hfx                , &
                   qfx               , wspd              , znt                ,                      &
@@ -100,7 +100,6 @@
  
  integer,intent(in):: &
     initflag,           &!
-    icloud_bl,          &!
     spp_pbl              !
 
  real(kind=kind_phys),intent(in):: &
@@ -543,7 +542,6 @@
             bl_mynn_cloudmix   = bl_mynn_cloudmix     , &
             bl_mynn_mixqt      = bl_mynn_mixqt        , &
             bl_mynn_ess        = bl_mynn_ess          , &
-            icloud_bl          = icloud_bl            , &
             spp_pbl            = spp_pbl              , &
             kts = kts , kte = kte , errmsg = errmsg , errflg = errflg )
 

--- a/WRF/module_bl_mynnedmf_driver.F90
+++ b/WRF/module_bl_mynnedmf_driver.F90
@@ -102,7 +102,7 @@
                   sub_thl3d         , sub_sqv3d         , det_thl3d          , det_sqv3d          , &
                   exch_h            , exch_m            , dqke               , qwt                , &
                   qshear            , qbuoy             , qdiss              , sh3d               , &
-                  sm3d              , spp_pbl           , pattern_spp_pbl    , icloud_bl          , &
+                  sm3d              , spp_pbl           , pattern_spp_pbl    ,                      &
                   bl_mynn_tkeadvect , tke_budget        , bl_mynn_cloudpdf   , bl_mynn_mixlength  , &
                   bl_mynn_closure   , bl_mynn_edmf      , bl_mynn_edmf_mom   , bl_mynn_edmf_tke   , &
                   bl_mynn_output    , bl_mynn_mixscalars, bl_mynn_mixaerosols, bl_mynn_mixnumcon  , &
@@ -128,7 +128,6 @@
  integer, intent(in) ::                                 &
          bl_mynn_cloudpdf,                              &
          bl_mynn_mixlength,                             &
-         icloud_bl,                                     &
          bl_mynn_edmf,                                  &
          bl_mynn_edmf_dd,                               &
          bl_mynn_edmf_mom,                              &
@@ -425,13 +424,11 @@
       !when NOT cold-starting on the first time step, update input
       if (initflag .eq. 0 .or. restart) THEN
          !update sgs cloud info.
-         if (icloud_bl > 0) then
-            do k=kts,kte
-               qc_bl1(k)     = qc_bl(i,k,j)
-               qi_bl1(k)     = qi_bl(i,k,j)
-               cldfra_bl1(k) = cldfra_bl(i,k,j)
-            enddo
-         endif
+         do k=kts,kte
+            qc_bl1(k)     = qc_bl(i,k,j)
+            qi_bl1(k)     = qi_bl(i,k,j)
+            cldfra_bl1(k) = cldfra_bl(i,k,j)
+         enddo
 
          !turbulennce variables
          do k=kts,kte
@@ -602,7 +599,6 @@
             bl_mynn_cloudmix   = bl_mynn_cloudmix     , &
             bl_mynn_mixqt      = bl_mynn_mixqt        , &
             bl_mynn_ess        = bl_mynn_ess          , &
-            icloud_bl          = icloud_bl            , &
             spp_pbl            = spp_pbl              , &
             kts = kts , kte = kte , errmsg = errmsg , errflg = errflg )
 
@@ -699,13 +695,11 @@
       endif
 
      !- Collect 3D ouput:
-      if (icloud_bl > 0) then
-         do k=kts,kte
-            qc_bl(i,k,j)     = qc_bl1(k)/(one - sqv1(k))
-            qi_bl(i,k,j)     = qi_bl1(k)/(one - sqv1(k))
-            cldfra_bl(i,k,j) = cldfra_bl1(k)
-         enddo
-      endif
+      do k=kts,kte
+         qc_bl(i,k,j)     = qc_bl1(k)/(one - sqv1(k))
+         qi_bl(i,k,j)     = qi_bl1(k)/(one - sqv1(k))
+         cldfra_bl(i,k,j) = cldfra_bl1(k)
+      enddo
 
       if (tke_budget .eq. 1) then
          do k=kts,kte

--- a/module_bl_mynnedmf.F90
+++ b/module_bl_mynnedmf.F90
@@ -199,11 +199,11 @@ contains
              qc_bl1             , qi_bl1            , cldfra_bl1        , &
              !namelist configurations option
              bl_mynn_tkeadvect  , tke_budget        , bl_mynn_cloudpdf  , &
-             bl_mynn_mixlength  , icloud_bl         , bl_mynn_closure   , &
+             bl_mynn_mixlength  , bl_mynn_closure   , bl_mynn_ess       , &
              bl_mynn_edmf       , bl_mynn_edmf_mom  , bl_mynn_edmf_tke  , &
              bl_mynn_mixscalars , bl_mynn_mixaerosols,bl_mynn_mixnumcon , &
              bl_mynn_output     , bl_mynn_cloudmix  , bl_mynn_mixqt     , &
-             bl_mynn_edmf_dd    , bl_mynn_ess       ,                     &
+             bl_mynn_edmf_dd    ,                                         &
              !3d emdf output
              edmf_a1            , edmf_w1           , edmf_qt1          , &
              edmf_thl1          , edmf_ent1         , edmf_qc1          , &
@@ -239,7 +239,6 @@ contains
  integer, intent(in) :: bl_mynn_cloudmix
  integer, intent(in) :: bl_mynn_mixqt
  integer, intent(in) :: bl_mynn_ess
- integer, intent(in) :: icloud_bl
  real(kind_phys), intent(in) :: bl_mynn_closure
 
  logical, intent(in) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC,&
@@ -594,18 +593,12 @@ contains
     if (tke_budget .eq. 1) then
        dqke1(kts:kte)=qke1(kts:kte)
     endif
-    if (icloud_bl > 0) then
-       cldfra_bl1_old(kts:kte)=cldfra_bl1(kts:kte)
-       qc_bl1_old(kts:kte)    =qc_bl1(kts:kte)
-       qi_bl1_old(kts:kte)    =qi_bl1(kts:kte)
-    else
-       cldfra_bl1    =zero
-       qc_bl1        =zero
-       qi_bl1        =zero
-       cldfra_bl1_old=zero
-       qc_bl1_old    =zero
-       qi_bl1_old    =zero
-    endif
+    cldfra_bl1_old(kts:kte)=cldfra_bl1(kts:kte)
+    qc_bl1_old(kts:kte)=qc_bl1(kts:kte)
+    qi_bl1_old(kts:kte)=qi_bl1(kts:kte)
+    cldfra_bl1 =zero
+    qc_bl1     =zero
+    qi_bl1     =zero
     dqc1       =zero
     dqi1       =zero
     dqs1       =zero
@@ -1060,11 +1053,9 @@ contains
              "SUSPICIOUS VALUES AT: i,k=",i,k," el1=",el1(k)
           IF ( km1(k) < 0. .OR. km1(k)> 2000.)print*,&
              "SUSPICIOUS VALUES AT: i,k=",i,k," km=",km1(k)
-          IF (icloud_bl > 0) then
-             IF (cldfra_bl1(k) < zero .OR. cldfra_bl1(k)> one)THEN
-                PRINT*,"SUSPICIOUS VALUES: CLDFRA_BL=",cldfra_bl1(k),&
-                                             " qc_bl=",qc_bl1(k)
-             endif
+          IF (cldfra_bl1(k) < zero .OR. cldfra_bl1(k)> one)THEN
+             PRINT*,"SUSPICIOUS VALUES: CLDFRA_BL=",cldfra_bl1(k),&
+                                          " qc_bl=",qc_bl1(k)
           endif
        enddo !end-k
     endif
@@ -6198,7 +6189,7 @@ END SUBROUTINE GET_PBLH
 !! original form. Some additions include:
 !!  -# scale-aware tapering as dx -> 0
 !!  -# transport of TKE (extra namelist option)
-!!  -# Chaboureau-Bechtold cloud fraction & coupling to radiation (when icloud_bl > 0)
+!!  -# Chaboureau-Bechtold cloud fraction & coupling to radiation
 !!  -# some extra limits for numerical stability
 !!
 !! This scheme remains under development, so consider it experimental code. 
@@ -6342,18 +6333,18 @@ END SUBROUTINE GET_PBLH
 
  ! chem/smoke
  integer, intent(in) :: nchem
- real(kind_phys),dimension(kts:kte,   nchem) :: chem1
- real(kind_phys),dimension(kts:kte+1, nchem) :: s_awchem1
- real(kind_phys),dimension(nchem)            :: chemn
+ real(kind_phys),dimension(kts:kte,   nchem)       :: chem1
+ real(kind_phys),dimension(kts:kte+1, nchem)       :: s_awchem1
+ real(kind_phys),dimension(nchem)                  :: chemn
  real(kind_phys),dimension(kts:kte+1,1:NUP, nchem) :: UPCHEM
  integer :: ic,cb_check
- real(kind_phys),dimension(kts:kte,   nchem) :: edmf_chem
+ real(kind_phys),dimension(kts:kte,   nchem)       :: edmf_chem
  logical, intent(in) :: mix_chem
  !generic scalars
  integer, intent(in) :: nscalars
- real(kind_phys),dimension(kts:kte,   nscalars) :: scalars
- real(kind_phys),dimension(kts:kte+1, nscalars) :: s_awscalars1
- real(kind_phys),dimension(nscalars)            :: scalarsn
+ real(kind_phys),dimension(kts:kte,   nscalars)    :: scalars
+ real(kind_phys),dimension(kts:kte+1, nscalars)    :: s_awscalars1
+ real(kind_phys),dimension(nscalars)               :: scalarsn
  real(kind_phys),dimension(kts:kte+1,1:NUP,nscalars) :: upscalars
  !local ktop for each plume
  integer,dimension(1:NUP) :: ktop_plume

--- a/tests/driver.F90
+++ b/tests/driver.F90
@@ -8,17 +8,17 @@ use module_bl_mynnedmf_wrf_tests
 
 implicit none
 
-call wrf_test(case='clr',bl_mynn_closure=2.6,bl_mynn_cloudpdf=2,bl_mynn_mixlength=2,icloud_bl=1,   &
+call wrf_test(case='clr',bl_mynn_closure=2.6,bl_mynn_cloudpdf=2,bl_mynn_mixlength=2,               &
       bl_mynn_edmf=1,bl_mynn_edmf_dd=1,bl_mynn_edmf_mom=1,bl_mynn_edmf_tke=1,bl_mynn_cloudmix=1,   &
       bl_mynn_mixqt=0,bl_mynn_mixscalars=0,bl_mynn_mixaerosols=0,bl_mynn_mixnumcon=0,bl_mynn_ess=1,&
       tke_budget=1)
 
-call wrf_test(case='clr',bl_mynn_closure=3.0,bl_mynn_cloudpdf=2,bl_mynn_mixlength=2,icloud_bl=1,   &
+call wrf_test(case='clr',bl_mynn_closure=3.0,bl_mynn_cloudpdf=2,bl_mynn_mixlength=2,               &
       bl_mynn_edmf=1,bl_mynn_edmf_dd=1,bl_mynn_edmf_mom=1,bl_mynn_edmf_tke=1,bl_mynn_cloudmix=1,   &
       bl_mynn_mixqt=0,bl_mynn_mixscalars=0,bl_mynn_mixaerosols=0,bl_mynn_mixnumcon=0,bl_mynn_ess=1,&
       tke_budget=1)
 
-call wrf_test(case='marine_StCu',bl_mynn_closure=3.0,bl_mynn_cloudpdf=2,bl_mynn_mixlength=2,icloud_bl=1,   &
+call wrf_test(case='marine_StCu',bl_mynn_closure=3.0,bl_mynn_cloudpdf=2,bl_mynn_mixlength=2,               &
       bl_mynn_edmf=1,bl_mynn_edmf_dd=1,bl_mynn_edmf_mom=1,bl_mynn_edmf_tke=1,bl_mynn_cloudmix=1,           &
       bl_mynn_mixqt=0,bl_mynn_mixscalars=0,bl_mynn_mixaerosols=0,bl_mynn_mixnumcon=0,bl_mynn_ess=1,        &
       tke_budget=1)

--- a/tests/module_bl_mynnedmf_wrf_tests.F90
+++ b/tests/module_bl_mynnedmf_wrf_tests.F90
@@ -49,7 +49,7 @@ module module_bl_mynnedmf_wrf_tests
     end subroutine init_mynn_edmf_flags
 
     !=================================================================================================================    
-    subroutine wrf_test(case,bl_mynn_closure,bl_mynn_cloudpdf,bl_mynn_mixlength,icloud_bl, &
+    subroutine wrf_test(case,bl_mynn_closure,bl_mynn_cloudpdf,bl_mynn_mixlength,           &
         bl_mynn_edmf,bl_mynn_edmf_dd,bl_mynn_edmf_mom,bl_mynn_edmf_tke,bl_mynn_cloudmix,   &
         bl_mynn_mixqt, bl_mynn_mixscalars, bl_mynn_mixaerosols,bl_mynn_mixnumcon,          &
         bl_mynn_ess,tke_budget)
@@ -70,7 +70,6 @@ module module_bl_mynnedmf_wrf_tests
         logical :: bl_mynn_tkeadvect, cycling
         integer :: bl_mynn_cloudpdf,                            &
                  bl_mynn_mixlength,                             &
-                 icloud_bl,                                     &
                  bl_mynn_edmf,                                  &
                  bl_mynn_edmf_dd,                               &
                  bl_mynn_edmf_mom,                              &
@@ -433,7 +432,7 @@ module module_bl_mynnedmf_wrf_tests
                   sub_thl3d         , sub_sqv3d         , det_thl3d          , det_sqv3d          , &
                   exch_h            , exch_m            , dqke               , qwt                , &
                   qshear            , qbuoy             , qdiss              , sh3d               , &
-                  sm3d              , spp_pbl           , pattern_spp_pbl    , icloud_bl          , &
+                  sm3d              , spp_pbl           , pattern_spp_pbl    ,                      &
                   bl_mynn_tkeadvect , tke_budget        , bl_mynn_cloudpdf   , bl_mynn_mixlength  , &
                   bl_mynn_closure   , bl_mynn_edmf      , bl_mynn_edmf_mom   , bl_mynn_edmf_tke   , &
                   bl_mynn_output    , bl_mynn_mixscalars, bl_mynn_mixaerosols, bl_mynn_mixnumcon  , &


### PR DESCRIPTION
This PR removes icloud_bl from the MYNN-EDMF scheme; however, it:

1. is still used in WRF radiation driver as a flag for coupling the subgrid clouds from the MYNN-EDMF to the radiation, but no longer is used as a package to allocate cldfra_bl, qc_bl, and qi_bl. They are now always allocated when the MYNN-EDMF is selected.
2. never was used in MPAS, The coupling of the MYNN-EDMF clouds to the radiation uses a different flag (config_radt_cld_scheme = "cld_fraction_mynn") in the cloudiness driver. 